### PR TITLE
📝docs: fix quote block in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
 ![The Road Not Taken](https://i.imgur.com/EvEsjr9.png)
 
-> Two roads diverged in a wood, and I—
-
-> I took the one less traveled by,
-
-> And that has made all the difference.
+> Two roads diverged in a wood, and I— <br>
+I took the one less traveled by, <br>
+And that has made all the difference.
 
 Inspired by Robert Frost's masterpiece, here's **The Road Not Taken**, a situational dilemma simulator. 🎲 🔮 
 


### PR DESCRIPTION
## Description
Apparently, Github README markdown wasn't working the way it should so I had to add `<br>` to break the quote lines.

## Ideal Solution
```
>line 1
line 2
```

## Workaround
```
>line 1 <br>
line 2
```

## Reason
They both give the same output in a normal MD file, however, for some unknown reason, the ideal solution sadly doesn't work on README.md

## Screenshot
![image](https://user-images.githubusercontent.com/44428198/97137061-e6c43780-177a-11eb-9c55-d3aa9bf4b0bf.png)
